### PR TITLE
Dockerize the Development Environment

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,22 @@
+# Running in Docker
+
+Download Docker for your system [here](https://docs.docker.com/get-docker/). 
+
+NOTE: After installation, make sure Docker daemon is up and running on your system before proceeding.
+
+## Build from Dockerfile
+
+`docker build -t blawx .`
+
+## Run container
+
+This will run the container in detached mode:
+
+`docker run -d -p 8080:80 blawx`
+
+NOTE: If there is another service running at port 8080 of your host machine, change 8080 to an open port.
+
+## Try Blawx!
+
+Navigate to http://localhost:8080/blawx.html to try out Blawx.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && \
+	apt-get install -y \
+	git \
+	curl \
+	apache2 \
+	libapache2-mod-php \
+	nodejs \
+	npm && \
+	npm install -g blockly xmlhttprequest
+
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
+	echo "AcceptFilter https none" >> /etc/apache2/apache2.conf && \
+	echo "AcceptFilter http none" >> /etc/apache2/apache2.conf
+
+RUN cd /etc/apache2/mods-enabled && \
+	ln -s ../mods-available/cgi.load
+
+RUN echo "export NODE_PATH=/usr/local/lib/node_modules" >> /etc/apache2/envvars
+
+RUN echo "www-data ALL=(root) NOPASSWD: /var/Flora-2/flora2/runflora" >> /etc/sudoers
+
+WORKDIR /var/www/html
+
+RUN git clone https://github.com/google/blockly blockly && \
+	cp -r ./blockly/media ./media && \
+	git clone -b dev https://github.com/Blawx/blawx blawx && \
+	cd blawx/interface && \
+	cp * /var/www/html && \
+	cd ../reasoner && \
+	cp reasoner.php /usr/lib/cgi-bin && \
+	cp decode.js /var/www/html && \
+	cp json2f2.py /var/www/html
+
+WORKDIR /var
+
+COPY flora2_Pyrus_nivalis_2_0.run .
+
+RUN mv flora2_Pyrus_nivalis_2_0.run flora2.run && \
+	sh flora2.run
+
+CMD ["apachectl", "-D", "FOREGROUND"]
+
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,9 @@ RUN git clone https://github.com/google/blockly blockly && \
 WORKDIR /var
 
 RUN wget -O flora2.run \
-	https://sourceforge.net/projects/flora/files/FLORA-2/2.0%20%28Pyrus%20nivalis%29/flora2_Pyrus_nivalis_2_0.run/download
+	https://sourceforge.net/projects/flora/files/FLORA-2/2.0%20%28Pyrus%20nivalis%29/flora2_Pyrus_nivalis_2_0.run/download && \
+	sh flora2.run
+	
 
 CMD ["apachectl", "-D", "FOREGROUND"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ WORKDIR /var
 RUN wget -O flora2.run \
 	https://sourceforge.net/projects/flora/files/FLORA-2/2.0%20%28Pyrus%20nivalis%29/flora2_Pyrus_nivalis_2_0.run/download && \
 	sh flora2.run
-	
 
 CMD ["apachectl", "-D", "FOREGROUND"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
 	apt-get install -y \
 	git \
-	curl \
+	wget \
 	apache2 \
 	libapache2-mod-php \
 	nodejs \
@@ -37,10 +37,8 @@ RUN git clone https://github.com/google/blockly blockly && \
 
 WORKDIR /var
 
-COPY flora2_Pyrus_nivalis_2_0.run .
-
-RUN mv flora2_Pyrus_nivalis_2_0.run flora2.run && \
-	sh flora2.run
+RUN wget -O flora2.run \
+	https://sourceforge.net/projects/flora/files/FLORA-2/2.0%20%28Pyrus%20nivalis%29/flora2_Pyrus_nivalis_2_0.run/download
 
 CMD ["apachectl", "-D", "FOREGROUND"]
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the results to the Blawx front end, or whichever other app made the request.
 
 ## How Can I Try It?
 The easiest way to try Blawx is to go to www.blawx.com. The current version of Blawx is available for free at that site, and has all
-the features of this package.
+the features of this package. [Alternatively, you can run Blawx in Docker.](DOCKER.md)
 
 ## How Can I Learn More?
 Right now, most of the useful information is at www.blawx.com/learn. I hope to increase the amount of documentation in this repository


### PR DESCRIPTION
Addresses #21 (single-machine containerization)

@Gauntlet173 I didn't run into any major issues! 

The SourceForge URL to the `flora2_Pyrus_nivalis_2_0.run` version of flora-2 is hardcoded into the Dockerfile; but we could easily replace it with the URL pointing to the latest version of flora-2 (i.e. https://sourceforge.net/projects/flora/files/latest/download) instead. Let me know if this should be changed!

edit: tested this on Docker Desktop Community 2.3.0.2 (45183)

Thanks Jason!