### PR TITLE
Update Dockerfile to use COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,14 +26,7 @@ RUN echo "www-data ALL=(root) NOPASSWD: /var/Flora-2/flora2/runflora" >> /etc/su
 WORKDIR /var/www/html
 
 RUN git clone https://github.com/google/blockly blockly && \
-	cp -r ./blockly/media ./media && \
-	git clone -b dev https://github.com/Blawx/blawx blawx && \
-	cd blawx/interface && \
-	cp * /var/www/html && \
-	cd ../reasoner && \
-	cp reasoner.php /usr/lib/cgi-bin && \
-	cp decode.js /var/www/html && \
-	cp json2f2.py /var/www/html
+	cp -r ./blockly/media ./media
 
 WORKDIR /var
 
@@ -42,5 +35,15 @@ RUN wget -O flora2.run \
 	sh flora2.run
 
 CMD ["apachectl", "-D", "FOREGROUND"]
+
+WORKDIR /var/www/html
+
+COPY . ./blawx
+
+COPY interface .
+
+COPY reasoner/decode.js reasoner/json2f2.py ./
+
+COPY reasoner/reasoner.php /usr/lib/cgi-bin
 
 EXPOSE 80


### PR DESCRIPTION
Addresses https://github.com/Blawx/blawx/issues/34

Hey Jason, the updated Dockerfile takes care of the redundancy of cloning blawx twice. And the COPY commands are at the final stages of the Docker build. I tested this on my machine successfully.

I'm happy to convert this PR into a draft PR and look into https://github.com/Blawx/blawx/issues/35 so I can eventually incorporate those changes within this PR. Otherwise, I'll open a separate PR to address https://github.com/Blawx/blawx/issues/35.

Let me know what you think, Jason! @Gauntlet173

Cheers,
Shiv